### PR TITLE
Patch ProportionTree:matchingParentsToChildren

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "dn-m/Collections" >= 1.16.6
-github "dn-m/ArithmeticTools"
+github "dn-m/ArithmeticTools" >= 0.8
 github "dn-m/IntervalTools"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "dn-m/Collections" "1.16.6"
-github "dn-m/ArithmeticTools" "0.7.1"
+github "dn-m/ArithmeticTools" "0.8"
 github "dn-m/IntervalTools" "0.6"

--- a/Rhythm/ProportionTree.swift
+++ b/Rhythm/ProportionTree.swift
@@ -166,7 +166,7 @@ internal func propagated(_ tree: DistanceTree) -> DistanceTree {
 
 /// - returns: Relative duration value scaled by the given `distance`.
 func decodeDuration(_ original: Int, _ distance: Int) -> Int {
-    return original * Int(pow(2, Double(distance)))
+    return Int(Double(original) * pow(2, Double(distance)))
 }
 
 /// - returns: Distance (in powers-of-two) from one relative durational value to another.

--- a/Rhythm/ProportionTree.swift
+++ b/Rhythm/ProportionTree.swift
@@ -80,16 +80,7 @@ internal func matchingParentsToChildren(_ tree: ProportionTree)
     let relativeDurations = trees.map { $0.value }
     let sum = relativeDurations.sum
     
-    var newDuration: Int {
-        switch compare(duration, sum) {
-        case .equal:
-            return duration
-        case .lessThan:
-            return closestPowerOfTwo(withCoefficient: duration, to: sum)!
-        case .greaterThan:
-            return duration / gcd(duration, sum)
-        }
-    }
+    let newDuration: Int = closestPowerOfTwo(withCoefficient: duration >> countTrailingZeros(duration), to: sum)!
     
     return .branch(newDuration, trees.map(matchingParentsToChildren))
 }

--- a/RhythmTests/ProportionTreeTests.swift
+++ b/RhythmTests/ProportionTreeTests.swift
@@ -116,14 +116,44 @@ class ProportionTreeTests: XCTestCase {
     
     func testmatchingParentsToChildrenSingleDepthDown() {
         
-        let tree = Tree.branch(6, [
+        var tree = Tree.branch(6, [
             .leaf(1),
             .leaf(1)
         ])
         
         XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
+
+		tree = Tree.branch(6, [
+			.leaf(2),
+			.leaf(1)
+			])
+
+		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
+
+		tree = Tree.branch(6, [
+			.leaf(3),
+			.leaf(1)
+			])
+
+		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
+
+		tree = Tree.branch(6, [
+			.leaf(1),
+			.leaf(1),
+			.leaf(1)
+			])
+
+		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
+
+		tree = Tree.branch(6, [
+			.leaf(1),
+			.leaf(2),
+			.leaf(1)
+			])
+
+		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
     }
-    
+
     func testmatchingParentsToChildrenSingleDepthUp() {
         
         let tree = Tree.branch(1, [

--- a/RhythmTests/ProportionTreeTests.swift
+++ b/RhythmTests/ProportionTreeTests.swift
@@ -114,45 +114,25 @@ class ProportionTreeTests: XCTestCase {
         XCTAssert(result == expected)
     }
     
-    func testmatchingParentsToChildrenSingleDepthDown() {
+    func testmatchingParentsToChildrenSingleDepthDownTwo() {
         
-        var tree = Tree.branch(6, [
+        let tree = Tree.branch(6, [
             .leaf(1),
             .leaf(1)
         ])
         
         XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
-
-		tree = Tree.branch(6, [
-			.leaf(2),
-			.leaf(1)
-			])
-
-		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
-
-		tree = Tree.branch(6, [
-			.leaf(3),
-			.leaf(1)
-			])
-
-		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
-
-		tree = Tree.branch(6, [
-			.leaf(1),
-			.leaf(1),
-			.leaf(1)
-			])
-
-		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
-
-		tree = Tree.branch(6, [
-			.leaf(1),
-			.leaf(2),
-			.leaf(1)
-			])
-
-		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
     }
+
+	func testmatchingParentsToChildrenSingleDepthDownThree() {
+
+		let tree = Tree.branch(6, [
+			.leaf(1),
+			.leaf(2)
+			])
+
+		XCTAssertEqual(matchingParentsToChildren(tree).value, 3)
+	}
 
     func testmatchingParentsToChildrenSingleDepthUp() {
         


### PR DESCRIPTION
This PR uses the newly-implemented countTrailingZeros from ArithmeticTools (branch topic/func/ctz) to simplify and `matchingParentsToChildren`. It also patches an issue with `decodeDuration` that would unintentionally return 0 for a negative distance input. Finally, it adds a test that will only pass once those other changes are made.