### PR TITLE
Refactor RhythmTree

### DIFF
--- a/Rhythm/MetricalContext.swift
+++ b/Rhythm/MetricalContext.swift
@@ -8,43 +8,36 @@
 
 /// The metrical context of a given `Leaf` (i.e., whether or not the musical event is "tied"
 /// from the previous event, and whether or not is a "rest" or an actual event.
-public typealias MetricalContext <T> = ContinuationOrInstance<AbsenceOrEvent<T>>
-
-/// Whether a context is a "rest" or an actual event of type `T`.
-public enum AbsenceOrEvent <T> {
-    
-    /// "Rest".
-    case absence
-    
-    /// Actual event of type `T`.
-    case event(T)
-}
-
-extension AbsenceOrEvent: CustomStringConvertible {
-    
-    // MARK: - CustomStringConvertible
-    
-    /// Printed description.
-    public var description: String {
-        switch self {
-        case .absence:
-            return "<>"
-        case .event(let value):
-            return "\(value)"
-        }
-    }
-}
-
+public typealias MetricalContext <T: Equatable> = ContinuationOrInstance<AbsenceOrEvent<T>>
 
 /// Whether a metrical context is "tied" over from the previous context, or if it is new
 /// instance of the generic `T`.
-public enum ContinuationOrInstance <T> {
+public enum ContinuationOrInstance <T: Equatable> {
     
     /// "Tied" over from previous context.
     case continuation
     
     /// New instance of generic `T`.
     case instance(T)
+}
+
+extension ContinuationOrInstance: Equatable {
+    
+    /// - returns: `true` if both values are equivalent. Otherwise, `false`.
+    public static func == <T: Equatable> (
+        lhs: ContinuationOrInstance<T>,
+        rhs: ContinuationOrInstance<T>
+    ) -> Bool
+    {
+        switch (lhs, rhs) {
+        case (.continuation, .continuation):
+            return true
+        case (.instance(let a), .instance(let b)):
+            return a == b
+        default:
+            return false
+        }
+    }
 }
 
 extension ContinuationOrInstance: CustomStringConvertible {
@@ -62,5 +55,44 @@ extension ContinuationOrInstance: CustomStringConvertible {
     }
 }
 
+/// Whether a context is a "rest" or an actual event of type `T`.
+public enum AbsenceOrEvent <T: Equatable> {
+    
+    /// "Rest".
+    case absence
+    
+    /// Actual event of type `T`.
+    case event(T)
+}
 
+extension AbsenceOrEvent: Equatable {
 
+    /// - returns: `true` if both values are equivalent. Otherwise, `false`.
+    public static func == <T: Equatable> (lhs: AbsenceOrEvent<T>, rhs: AbsenceOrEvent<T>)
+        -> Bool
+    {
+        switch (lhs, rhs) {
+        case (.absence, .absence):
+            return true
+        case (.event(let a), .event(let b)):
+            return a == b
+        default:
+            return false
+        }
+    }
+}
+
+extension AbsenceOrEvent: CustomStringConvertible {
+    
+    // MARK: - CustomStringConvertible
+    
+    /// Printed description.
+    public var description: String {
+        switch self {
+        case .absence:
+            return "<>"
+        case .event(let value):
+            return "\(value)"
+        }
+    }
+}

--- a/Rhythm/MetricalDurationTree.swift
+++ b/Rhythm/MetricalDurationTree.swift
@@ -25,6 +25,11 @@ extension Tree where T == MetricalDuration {
         }
     }
     
+    /// - returns: `Tree` containing the inherited scale of each node contained herein.
+    public var scaling: Tree<Float> {
+        return map { $0.numerator }.scaling
+    }
+    
     /// Create a `MetricalDurationTree` with the beat values of the given `proportionTree`
     /// with the given `subdivision`.
     ///

--- a/Rhythm/ProportionTree.swift
+++ b/Rhythm/ProportionTree.swift
@@ -16,6 +16,25 @@ public typealias ProportionTree = Tree<Int>
 
 extension Tree where T == Int {
     
+    public var scaling: Tree<Float> {
+
+        func traverse(_ tree: ProportionTree, accum: Float) -> Tree<Float> {
+            
+            switch tree {
+            case .leaf:
+                return .leaf(accum)
+                
+            case .branch(let duration, let trees):
+                
+                let sum = trees.map { $0.value }.sum
+                let scale = Float(duration) / Float(sum)
+                return .branch(accum, trees.map { traverse($0, accum: scale * accum) })
+            }
+        }
+        
+        return traverse(self, accum: 1)
+    }
+    
     /// - returns: A new `ProportionTree` in which the value of each node can be represented
     /// with the same subdivision-level (denominator).
     public var normalized: ProportionTree {

--- a/Rhythm/RhythmTree.swift
+++ b/Rhythm/RhythmTree.swift
@@ -9,64 +9,45 @@
 import Collections
 import ArithmeticTools
 
-/// Wraps heterogeneous data types for `leaf` and `branch` cases in a `RhythmTree`.
-///
-/// In a `RhythmTree`, a `branch` holds only a `MetricalDuration`, while a `leaf` holds both a
-/// `MetricalDuration` and a `MetricalContext<T>`.
-///
-/// Operations on nodes within a `RhythmTree` will have to deconstruct this type.
-public enum RhythmNode <T> {
+/// `Tree` that extends a `MetricalDurationTree` with `MetricalContext<T>` values for `leaf`
+/// nodes.
+public struct RhythmTree <T: Equatable> {
     
-    /// `RhythmTree.leaf` nodes hold a `MetricalDuration` and a `MetricalContext<T>`
-    case leaf(MetricalDuration, MetricalContext<T>)
+    public let metricalDurationTree: MetricalDurationTree
+    public let leafContexts: [MetricalContext<T>]
     
-    /// `RhythmTree.branch` nodes hold only a `MetricalDuration`.
-    case branch(MetricalDuration)
-    
-    /// The `MetricalDuration` value of this `RhythmNode`.
-    public var duration: MetricalDuration {
-        switch self {
-        case .leaf(let duration, _):
-            return duration
-        case .branch(let duration):
-            return duration
+    public init(
+        _ metricalDurationTree: MetricalDurationTree,
+        _ leafContexts: [MetricalContext<T>]
+    )
+    {
+        
+        /// This is an expensive check (`tree.leaves` is O(n))
+        guard leafContexts.count == metricalDurationTree.leaves.count else {
+            fatalError("Incompatible leaf contexts for tree")
         }
+        
+        self.metricalDurationTree = metricalDurationTree
+        self.leafContexts = leafContexts
+    }
+    
+    // TODO: Add node with contexts
+    // TODO: Insert ""
+    // TODO: Remove node
+}
+
+extension RhythmTree: Equatable {
+    
+    public static func == <T: Equatable> (lhs: RhythmTree<T>, rhs: RhythmTree<T>) -> Bool {
+        return (
+            lhs.metricalDurationTree == rhs.metricalDurationTree &&
+            lhs.leafContexts == rhs.leafContexts
+        )
     }
 }
 
-/// `Tree` that extends a `MetricalDurationTree` with `MetricalContext<T>` values in the `leaf`
-/// nodes.
-public typealias RhythmTree = Tree<RhythmNode<Int>>
 
-extension Tree where T == RhythmNode<Int> {
-    
-    /// The `MetricalDuration` value of this `RhythmTree` node.
-    public var duration: MetricalDuration {
-        
-        switch self {
-        case .leaf(let node):
-            return node.duration
-        case .branch(let node, _):
-            return node.duration
-        }
-    }
-    
-    /// Create a `RhythmTree` with the `MetricalDuration` values of the given 
-    /// `metricalDurationTree`, mapped with `event`.
-    public init(_ metricalDurationTree: MetricalDurationTree) {
-        
-        func traverse(_ tree: MetricalDurationTree) -> RhythmTree {
-            
-            switch tree {
-            case .leaf(let value):
-                let leaf = RhythmNode.leaf(value, .instance(.event(1)))
-                return .leaf(leaf)
-            case .branch(let value, let trees):
-                let branch = RhythmNode<Int>.branch(value)
-                return .branch(branch, trees.map(traverse))
-            }
-        }
-        
-        self = traverse(metricalDurationTree)
-    }
+/// - returns: `RhythmTree` with the given `MetricalDurationTree` and `MetricalContext` values.
+public func * <T> (lhs: MetricalDurationTree, rhs: [MetricalContext<T>]) -> RhythmTree<T> {
+    return RhythmTree(lhs, rhs)
 }

--- a/RhythmTests/ProportionTreeTests.swift
+++ b/RhythmTests/ProportionTreeTests.swift
@@ -273,4 +273,42 @@ class ProportionTreeTests: XCTestCase {
         
         XCTAssert(tree == normalizedTree)
     }
+    
+    func testScaleSimple() {
+        
+        let tree = ProportionTree([1,[1,1,1]])
+        
+        let value: Float = 2/3
+        let expected = Tree<Float>.branch(1, [
+            .leaf(value),
+            .leaf(value),
+            .leaf(value)
+        ])
+        
+        XCTAssert(tree.scaling == expected)
+    }
+//
+//    func testScaleNested() {
+//        
+//        let tree = ProportionTree([3,[2,[4,[2,4,[3,[4,4,3]]]],1]])
+//        
+//        let level1: Float = 6/7
+//        let level2: Float = 8/9
+//        let level3: Float = 12/11
+//        let expected = Tree.branch(1, [
+//            .leaf(level1),
+//            .branch(level1, [
+//                .leaf(level1 * level2),
+//                .leaf(level1 * level2),
+//                .branch(level1 * level2, [
+//                    .leaf(level1 * level2 * level3),
+//                    .leaf(level1 * level2 * level3),
+//                    .leaf(level1 * level2 * level3)
+//                ])
+//            ]),
+//            .leaf(level1)
+//        ])
+//        
+//        XCTAssert(tree.scaling == expected)
+//    }
 }

--- a/RhythmTests/RhythmTreeTests.swift
+++ b/RhythmTests/RhythmTreeTests.swift
@@ -12,5 +12,16 @@ import Rhythm
 
 class RhythmTreeTests: XCTestCase {
 
-
+    func testInit() {
+        
+        let metricalDurationTree = 1/>8 * [1,2,3]
+        
+        let contexts: [MetricalContext<Int>] = [
+            .instance(.event(1)),
+            .continuation,
+            .instance(.absence)
+        ]
+        
+        _ = metricalDurationTree * contexts
+    }
 }


### PR DESCRIPTION
Restructure `RhythmTree` as a wrapper of a `MetricalDurationTree` and `[MetricalContext<T>]`.