### PR TITLE
Rename MetricalDurationTree.leafOffsets -> offsets

### DIFF
--- a/Rhythm/MetricalDurationTree.swift
+++ b/Rhythm/MetricalDurationTree.swift
@@ -32,7 +32,7 @@ extension Tree where T == MetricalDuration {
     
     /// - returns: Array of tuples containing the scaled offset from the start of this
     /// `MetricalDurationTree`.
-    public var leafOffsets: [Fraction] {
+    public var offsets: [Fraction] {
         return zip(leaves.accumulatingRight, scaling.leaves).map { $0 * $1 }
     }
     

--- a/RhythmTests/MetricalDurationTreeTests.swift
+++ b/RhythmTests/MetricalDurationTreeTests.swift
@@ -145,7 +145,7 @@ class MetricalDurationTreeTests: XCTestCase {
     
     func testLeafOffsets() {
         let tree = 1/>8 * [1,1,1]
-        XCTAssertEqual(tree.leafOffsets, [Fraction(0,1), Fraction(1,24), Fraction(1,12)])
+        XCTAssertEqual(tree.offsets, [Fraction(0,1), Fraction(1,24), Fraction(1,12)])
     }
     
     func testLengthsAllTies() {


### PR DESCRIPTION
Fixes #18.