### PR TITLE
Interpolation.Easing: use asserts intead of throwing

### DIFF
--- a/Rhythm/Interpolation.swift
+++ b/Rhythm/Interpolation.swift
@@ -15,12 +15,6 @@ public struct Interpolation {
     /// Easing of `Interpolation`.
     public enum Easing {
 
-        // MARK: - Associated Types
-
-        public enum Error: Swift.Error {
-            case valueNotInDomain(Double, String)
-        }
-
         /// Linear interpolation.
         case linear
 

--- a/Rhythm/Interpolation.swift
+++ b/Rhythm/Interpolation.swift
@@ -37,11 +37,9 @@ public struct Interpolation {
         case sineInOut
 
         /// - returns: The easing function evaluated at `x`.
-        func evaluate(at x: Double) throws -> Double {
+        func evaluate(at x: Double) -> Double {
 
-            guard (0...1).contains(x) else {
-                throw Error.valueNotInDomain(x, "Input must lie in [0, 1]")
-            }
+            assert((0...1).contains(x), "\(#function): input must lie in [0, 1]")
 
             switch self {
 
@@ -50,18 +48,14 @@ public struct Interpolation {
 
             case .powerIn(let e):
 
-                guard e > 0 else {
-                    throw Error.valueNotInDomain(e, "Exponent must be positive")
-                }
+                assert(e > 0, "\(#function): powerIn exponent must be positive")
 
                 // x^e
                 return pow(x, e)
 
             case .powerInOut(let e):
 
-                guard e >= 1 else {
-                    throw Error.valueNotInDomain(e, "Exponent must be at least 1")
-                }
+                assert(e >= 1, "\(#function): powerInOut exponent must be >= 1")
 
                 if x <= 0.5 {
                     // (2^(e-1)) * x^e
@@ -73,13 +67,8 @@ public struct Interpolation {
 
             case .exponentialIn(let b):
 
-                guard b > 0 else {
-                    throw Error.valueNotInDomain(b, "Base must be positive")
-                }
-
-                guard b != 1 else {
-                    throw Error.valueNotInDomain(b, "Base must not be 1")
-                }
+                assert(b > 0, "\(#function): exponentialIn base must be > 0")
+                assert(b != 1, "\(#function): exponentialIn base must not be 1")
 
                 // ((b^x)-1) / (b-1)
                 return (pow(b, x)-1) / (b-1)
@@ -91,11 +80,9 @@ public struct Interpolation {
         }
 
         /// - returns: The integral of the easing function from 0 to `x`.
-        func integrate(at x: Double) throws -> Double {
+        func integrate(at x: Double) -> Double {
 
-            guard (0...1).contains(x) else {
-                throw Error.valueNotInDomain(x, "Input must lie in [0, 1]")
-            }
+            assert((0...1).contains(x), "\(#function): input must lie in [0, 1]")
 
             switch self {
 
@@ -105,18 +92,14 @@ public struct Interpolation {
 
             case .powerIn(let e):
 
-                guard e > 0 else {
-                    throw Error.valueNotInDomain(e, "Exponent must be positive")
-                }
+                assert(e > 0, "\(#function): exponent must be positive")
 
                 // x^(e+1) / (e+1)
                 return pow(x, e + 1) / (e + 1)
 
             case .powerInOut(let e):
 
-                guard e >= 1 else {
-                    throw Error.valueNotInDomain(e, "Exponent must be at least 1")
-                }
+                assert(e > 0, "\(#function): Exponent must be at least 1")
 
                 if x <= 0.5 {
                     // (2^(e-1) / (e+1)) * x^(e+1)
@@ -131,13 +114,8 @@ public struct Interpolation {
 
             case .exponentialIn(let b):
 
-                guard b > 0 else {
-                    throw Error.valueNotInDomain(b, "Base must be positive")
-                }
-
-                guard b != 1 else {
-                    throw Error.valueNotInDomain(b, "Base must not be 1")
-                }
+                assert(b > 0, "\(#function): Base must be positive")
+                assert(b != 1, "\(#function): Base must not be 1")
 
                 // ((b^x)/ln b) - x) / (b-1)
                 return ((pow(b, x)/log(b)) - x) / (b-1)

--- a/Rhythm/Interpolation.swift
+++ b/Rhythm/Interpolation.swift
@@ -176,7 +176,7 @@ public struct Interpolation {
         let (start, end, _, _) = normalizedValues(offset: metricalOffset)
         let x = (Fraction(metricalOffset) / Fraction(metricalDuration)).doubleValue
         let ratio = end.beatsPerMinute / start.beatsPerMinute
-        let xEased = try! easing.evaluate(at: x)
+        let xEased = easing.evaluate(at: x)
         let scaledBpm = start.beatsPerMinute * pow(ratio, xEased)
         return Tempo(scaledBpm, subdivision: start.subdivision)
     }

--- a/Rhythm/Interpolation.swift
+++ b/Rhythm/Interpolation.swift
@@ -41,34 +41,23 @@ public struct Interpolation {
                 return x
 
             case .powerIn(let e):
-
                 assert(e > 0, "\(#function): powerIn exponent must be positive")
-
-                // x^e
                 return pow(x, e)
 
             case .powerInOut(let e):
-
                 assert(e >= 1, "\(#function): powerInOut exponent must be >= 1")
-
                 if x <= 0.5 {
-                    // (2^(e-1)) * x^e
                     return pow(x, e) * pow(2, e - 1)
                 } else {
-                    // (1-x)^e * -(2^(e-1)) + 1
                     return pow(1 - x, e) * -pow(2, e - 1) + 1
                 }
 
             case .exponentialIn(let b):
-
                 assert(b > 0, "\(#function): exponentialIn base must be > 0")
                 assert(b != 1, "\(#function): exponentialIn base must not be 1")
-
-                // ((b^x)-1) / (b-1)
                 return (pow(b, x)-1) / (b-1)
 
             case .sineInOut:
-                // (1 - cos(π*x)) / 2
                 return 0.5 * (1 - cos(x * .pi))
             }
         }
@@ -81,41 +70,26 @@ public struct Interpolation {
             switch self {
 
             case .linear:
-                // x^2 / 2
                 return pow(x, 2) / 2
 
             case .powerIn(let e):
-
                 assert(e > 0, "\(#function): exponent must be positive")
-
-                // x^(e+1) / (e+1)
                 return pow(x, e + 1) / (e + 1)
 
             case .powerInOut(let e):
-
                 assert(e > 0, "\(#function): Exponent must be at least 1")
-
                 if x <= 0.5 {
-                    // (2^(e-1) / (e+1)) * x^(e+1)
                     return pow(2, e-1) / (e+1) * pow(x, (e+1))
                 } else {
-                    // (2^(e-1) * (1-x)^(1+e)) / (1+e) + x
-                    // But since this is a piecewise calculation, we have to subtract this
-                    // evaluated at 0.5 and add the value at 0.5 of the function directly above.
-                    // This actually just amounts to adding a -.5 term; everything else cancels out.
                     return pow(2, e-1) * pow(1-x, 1+e) / (1+e) + x - 0.5
                 }
 
             case .exponentialIn(let b):
-
                 assert(b > 0, "\(#function): Base must be positive")
                 assert(b != 1, "\(#function): Base must not be 1")
-
-                // ((b^x)/ln b) - x) / (b-1)
                 return ((pow(b, x)/log(b)) - x) / (b-1)
 
             case .sineInOut:
-                //  (x - (sin(π*x))/π) / 2
                 return (x - sin(.pi * x) / .pi) / 2
             }
         }

--- a/RhythmTests/EasingEvaluateTests.swift
+++ b/RhythmTests/EasingEvaluateTests.swift
@@ -10,24 +10,6 @@ import XCTest
 
 class EasingEvaluateTests: XCTestCase {
 
-    // MARK: General
-
-    func testEasingErrorLessThanZero() {
-
-        let x: Double = -0.5
-        let ease = Interpolation.Easing.linear
-
-        XCTAssertThrowsError(try ease.evaluate(at: x))
-    }
-
-    func testEasingErrorGreaterThanOne() {
-
-        let x: Double = 1.5
-        let ease = Interpolation.Easing.linear
-
-        XCTAssertThrowsError(try ease.evaluate(at: x))
-    }
-
     // MARK: Linear
 
     func testLinear() {
@@ -35,13 +17,8 @@ class EasingEvaluateTests: XCTestCase {
         let x: Double = 0.5
         let ease = Interpolation.Easing.linear
         let expected = x
-
-        do {
-            let result = try ease.evaluate(at: x)
-            XCTAssertEqual(result, expected)
-        } catch {
-            XCTFail()
-        }
+        let result = ease.evaluate(at: x)
+        XCTAssertEqual(result, expected)
     }
 
     // MARK: - PowerIn
@@ -51,13 +28,8 @@ class EasingEvaluateTests: XCTestCase {
         let x: Double = 0.5
         let ease = Interpolation.Easing.powerIn(exponent: 1)
         let expected = 0.5
-
-        do {
-            let result = try ease.evaluate(at: x)
-            XCTAssertEqual(result, expected)
-        } catch {
-            XCTFail()
-        }
+        let result = ease.evaluate(at: x)
+        XCTAssertEqual(result, expected)
     }
 
     func testPowerInTwo() {
@@ -65,13 +37,8 @@ class EasingEvaluateTests: XCTestCase {
         let x: Double = 0.5
         let ease = Interpolation.Easing.powerIn(exponent: 2)
         let expected = 0.25
-
-        do {
-            let result = try ease.evaluate(at: x)
-            XCTAssertEqual(result, expected)
-        } catch {
-            XCTFail()
-        }
+        let result = ease.evaluate(at: x)
+        XCTAssertEqual(result, expected)
     }
 
     func testPowerInHalf() {
@@ -79,20 +46,8 @@ class EasingEvaluateTests: XCTestCase {
         let x: Double = 0.5
         let ease = Interpolation.Easing.powerIn(exponent: 0.5)
         let expected = 0.70710678118 // 1 / sqrt(2)
-        do {
-            let result = try ease.evaluate(at: x)
-            XCTAssertEqualWithAccuracy(result, expected, accuracy: 1e-6)
-        } catch {
-            XCTFail()
-        }
-    }
-
-    func testPowerInError() {
-
-        let x: Double = 0.5
-        let ease = Interpolation.Easing.powerIn(exponent: -2)
-
-        XCTAssertThrowsError(try ease.evaluate(at: x))
+        let result = ease.evaluate(at: x)
+        XCTAssertEqualWithAccuracy(result, expected, accuracy: 1e-6)
     }
 
     // MARK: - PowerInOut
@@ -102,45 +57,29 @@ class EasingEvaluateTests: XCTestCase {
         let x: Double = 0.25
         let ease = Interpolation.Easing.powerInOut(exponent: 1)
         let expected = 0.25
-
-        do {
-            let result = try ease.evaluate(at: x)
-            XCTAssertEqual(result, expected)
-        } catch {
-            XCTFail()
-        }
+        let result = ease.evaluate(at: x)
+        XCTAssertEqual(result, expected)
     }
 
     func testPowerInOutTwo() {
 
         let ease = Interpolation.Easing.powerInOut(exponent: 2)
 
-        XCTAssertEqual(try ease.evaluate(at: 0), 0)
-        XCTAssertEqual(try ease.evaluate(at: 0.25), 0.125)
-        XCTAssertEqual(try ease.evaluate(at: 0.5), 0.5)
-        XCTAssertEqual(try ease.evaluate(at: 0.75), 0.875)
-        XCTAssertEqual(try ease.evaluate(at: 1), 1)
+        XCTAssertEqual(ease.evaluate(at: 0), 0)
+        XCTAssertEqual(ease.evaluate(at: 0.25), 0.125)
+        XCTAssertEqual(ease.evaluate(at: 0.5), 0.5)
+        XCTAssertEqual(ease.evaluate(at: 0.75), 0.875)
+        XCTAssertEqual(ease.evaluate(at: 1), 1)
     }
 
     func testPowerInOutThree() {
 
         let ease = Interpolation.Easing.powerInOut(exponent: 3)
-
-        XCTAssertEqual(try ease.evaluate(at: 0), 0)
-        XCTAssertEqual(try ease.evaluate(at: 0.25), 0.0625)
-        XCTAssertEqual(try ease.evaluate(at: 0.5), 0.5)
-        XCTAssertEqual(try ease.evaluate(at: 0.75), 0.9375)
-        XCTAssertEqual(try ease.evaluate(at: 1), 1)
-    }
-
-    func testPowerInOutErrorNegativeExponent() {
-        let ease = Interpolation.Easing.powerInOut(exponent: -2)
-        XCTAssertThrowsError(try ease.evaluate(at: 0))
-    }
-
-    func testPowerInOutErrorPositiveExponent() {
-        let ease = Interpolation.Easing.powerInOut(exponent: 0.5)
-        XCTAssertThrowsError(try ease.evaluate(at: 0))
+        XCTAssertEqual(ease.evaluate(at: 0), 0)
+        XCTAssertEqual(ease.evaluate(at: 0.25), 0.0625)
+        XCTAssertEqual(ease.evaluate(at: 0.5), 0.5)
+        XCTAssertEqual(ease.evaluate(at: 0.75), 0.9375)
+        XCTAssertEqual(ease.evaluate(at: 1), 1)
     }
 
     // MARK: - SineInOut
@@ -158,7 +97,7 @@ class EasingEvaluateTests: XCTestCase {
         ]
 
         for (input, expected) in zip(inputs, expecteds) {
-            XCTAssertEqualWithAccuracy(try ease.evaluate(at: input), expected, accuracy: 1e-12)
+            XCTAssertEqualWithAccuracy(ease.evaluate(at: input), expected, accuracy: 1e-12)
         }
     }
 }

--- a/RhythmTests/EasingIntegrateTests.swift
+++ b/RhythmTests/EasingIntegrateTests.swift
@@ -10,23 +10,6 @@ import XCTest
 
 class EasingIntegrateTests: XCTestCase {
 
-    // MARK: General
-    func testEasingErrorLessThanZero() {
-
-        let x: Double = -0.5
-        let ease = Interpolation.Easing.linear
-
-        XCTAssertThrowsError(try ease.integrate(at: x))
-    }
-
-    func testEasingErrorGreaterThanOne() {
-
-        let x: Double = 1.5
-        let ease = Interpolation.Easing.linear
-
-        XCTAssertThrowsError(try ease.integrate(at: x))
-    }
-
     // MARK: Linear
     func testLinear() {
 
@@ -35,7 +18,7 @@ class EasingIntegrateTests: XCTestCase {
         let ease = Interpolation.Easing.linear
 
         for (x, expected) in zip(xs, ys) {
-            XCTAssertEqual(try ease.integrate(at: x), expected)
+            XCTAssertEqual(ease.integrate(at: x), expected)
         }
     }
 
@@ -47,7 +30,7 @@ class EasingIntegrateTests: XCTestCase {
         let ease = Interpolation.Easing.powerIn(exponent: 1)
 
         for (x, expected) in zip(xs, ys) {
-            XCTAssertEqual(try ease.integrate(at: x), expected)
+            XCTAssertEqual(ease.integrate(at: x), expected)
         }
     }
 
@@ -58,7 +41,7 @@ class EasingIntegrateTests: XCTestCase {
         let ease = Interpolation.Easing.powerIn(exponent: 2)
 
         for (x, expected) in zip(xs, ys) {
-            XCTAssertEqual(try ease.integrate(at: x), expected)
+            XCTAssertEqual(ease.integrate(at: x), expected)
         }
     }
 
@@ -69,16 +52,8 @@ class EasingIntegrateTests: XCTestCase {
         let ease = Interpolation.Easing.powerIn(exponent: 0.5)
 
         for (x, expected) in zip(xs, ys) {
-            XCTAssertEqualWithAccuracy(try ease.integrate(at: x), expected, accuracy: 1e-10)
+            XCTAssertEqualWithAccuracy(ease.integrate(at: x), expected, accuracy: 1e-10)
         }
-    }
-
-    func testPowerInError() {
-
-        let x: Double = 0.5
-        let ease = Interpolation.Easing.powerIn(exponent: -2)
-
-        XCTAssertThrowsError(try ease.integrate(at: x))
     }
 
     // MARK: - PowerInOut
@@ -90,7 +65,7 @@ class EasingIntegrateTests: XCTestCase {
         let ease = Interpolation.Easing.powerInOut(exponent: 1)
 
         for (x, expected) in zip(xs, ys) {
-            XCTAssertEqual(try ease.integrate(at: x), expected)
+            XCTAssertEqual(ease.integrate(at: x), expected)
         }
     }
 
@@ -103,7 +78,7 @@ class EasingIntegrateTests: XCTestCase {
         let ease = Interpolation.Easing.powerInOut(exponent: 2)
 
         for (x, expected) in zip(xs, ys) {
-            XCTAssertEqualWithAccuracy(try ease.integrate(at: x), expected, accuracy: 1e-6)
+            XCTAssertEqualWithAccuracy(ease.integrate(at: x), expected, accuracy: 1e-6)
         }
     }
 
@@ -116,18 +91,8 @@ class EasingIntegrateTests: XCTestCase {
         let ease = Interpolation.Easing.powerInOut(exponent: 3)
 
         for (x, expected) in zip(xs, ys) {
-            XCTAssertEqualWithAccuracy(try ease.integrate(at: x), expected, accuracy: 1e-6)
+            XCTAssertEqualWithAccuracy(ease.integrate(at: x), expected, accuracy: 1e-6)
         }
-    }
-
-    func testPowerInOutErrorNegativeExponent() {
-        let ease = Interpolation.Easing.powerInOut(exponent: -2)
-        XCTAssertThrowsError(try ease.integrate(at: 0))
-    }
-
-    func testPowerInOutErrorPositiveExponent() {
-        let ease = Interpolation.Easing.powerInOut(exponent: 0.5)
-        XCTAssertThrowsError(try ease.integrate(at: 0))
     }
 
     // MARK: - SineInOut
@@ -140,7 +105,7 @@ class EasingIntegrateTests: XCTestCase {
         let expecteds: [Double] = [0, 0.0124605, 0.0908451, 0.26246, 0.5]
         
         for (input, expected) in zip(inputs, expecteds) {
-            XCTAssertEqualWithAccuracy(try ease.integrate(at: input), expected, accuracy: 1e-6)
+            XCTAssertEqualWithAccuracy(ease.integrate(at: input), expected, accuracy: 1e-6)
         }
     }
 }


### PR DESCRIPTION
This simplifies the logic of using interpolations/easings and reduces obvious sanity checks to debug-build asserts.

Tests are also updated to accommodate this.